### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/BetaNYC/citygram-services-nyc.png?label=ready&title=Ready)](https://waffle.io/BetaNYC/citygram-services-nyc)
 # spy-glass (aka Citygram connector)
 
 __Spyglass__  is a [Code for America](https://github.com/codeforamerica) project by the [Charlotte Team](http://team-charlotte.tumblr.com/) for the [2014 fellowship](http://www.codeforamerica.org/geeks/our-geeks/2014-fellows/).


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/BetaNYC/citygram-services-nyc

This was requested by a real person (user dirkkelly) on waffle.io, we're not trying to spam you.
