### PR TITLE
Error more helpfully when the Socrata API returns an error

### DIFF
--- a/lib/spy_glass/client/socrata.rb
+++ b/lib/spy_glass/client/socrata.rb
@@ -4,15 +4,27 @@ module SpyGlass
   module Client
     class Socrata < SpyGlass::Client::JSON
       MissingAuthToken = Class.new StandardError
+      ApiError = Class.new StandardError
 
       def initialize(attrs, &block)
         @auth_token = attrs[:auth_token] || ENV['SOCRATA_APP_TOKEN'] || raise(MissingAuthToken)
-        super attrs, &block
+        super attrs, &wrap_api_errors(&block)
       end
 
       def build_connection(conn)
         super(conn)
         conn.headers['X-App-Token'] = @auth_token
+      end
+
+      private
+
+      def wrap_api_errors(&transform)
+        -> (response) {
+          if response.is_a?(Hash) && response["error"]
+            raise(ApiError.new(response["message"]))
+          end
+          transform.call(response)
+        }
       end
     end
   end


### PR DESCRIPTION
Just a way to get more helpful errors out of the app when the Socrata API returns its error response.

![screen shot 2015-10-24 at 1 54 17 pm](https://cloud.githubusercontent.com/assets/239754/10711855/c5ffd160-7a56-11e5-9a78-de123ff84d67.png)
